### PR TITLE
Remove PHP closing tag to fix this

### DIFF
--- a/app/code/local/Mage/Core/Exception.php
+++ b/app/code/local/Mage/Core/Exception.php
@@ -16,7 +16,6 @@
   *    along with ProxiBlue NewRelic Module.  
   *    If not, see <http://www.gnu.org/licenses/>.
   **/
-?>
 
 /**
  * Magento Core Exception
@@ -26,6 +25,7 @@
  * @category   Mage
  * @package    Mage_Core
  */
+ 
 class Mage_Core_Exception extends Exception {
 
     protected $_messages = array();


### PR DESCRIPTION
This file was formatted incorrectly the closing PHP tag didn't need to be there after the top License agreement.
