### PR TITLE
Fixed ajax requests for cases when store is installed into a subfolder

### DIFF
--- a/app/code/community/ProxiBlue/NewRelic/etc/config.xml
+++ b/app/code/community/ProxiBlue/NewRelic/etc/config.xml
@@ -135,5 +135,14 @@
                 </args>
             </newrelic>
         </routers>
-    </frontend>    
+    </frontend>
+    <adminhtml>
+        <layout>
+            <updates>
+                <newrelic>
+                    <file>newrelic.xml</file>
+                </newrelic>
+            </updates>
+        </layout>
+    </adminhtml>
 </config>

--- a/app/design/adminhtml/default/default/layout/newrelic.xml
+++ b/app/design/adminhtml/default/default/layout/newrelic.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<layout version="0.1.0">
+    <default>
+        <reference name="before_body_end">
+            <block name="newrelic_js_init" type="core/template" template="newrelic/init_js.phtml"/>
+        </reference>
+    </default>
+</layout>

--- a/app/design/adminhtml/default/default/template/newrelic/init_js.phtml
+++ b/app/design/adminhtml/default/default/template/newrelic/init_js.phtml
@@ -1,0 +1,3 @@
+<script type="text/javascript">
+    var newrelic_base_url = '<?php echo Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB); ?>';
+</script>

--- a/js/newrelic.js
+++ b/js/newrelic.js
@@ -10,7 +10,7 @@ Array.prototype.remove = function() {
 };
 
 function fetchApplicationNames() {
-    new Ajax.Request('/newrelic/api/names/key/'+$('newrelic_api_api_key').value, {
+    new Ajax.Request(newrelic_base_url + 'newrelic/api/names/key/'+$('newrelic_api_api_key').value, {
         onSuccess: function(response) {
             var json = response.responseText.evalJSON();
             if(json.error) {
@@ -39,7 +39,7 @@ function fetchApplicationNames() {
 }
 
 function fetchAccountDetails() {
-    new Ajax.Request('/newrelic/api/accountDetails/key/'+$('newrelic_api_api_key').value, {
+    new Ajax.Request(newrelic_base_url + 'newrelic/api/accountDetails/key/'+$('newrelic_api_api_key').value, {
         onSuccess: function(response) {
             var json = response.responseText.evalJSON();
             if(json.error) {


### PR DESCRIPTION
Hello guys. Recently, we have faced with a small trouble. 
When Magento is installed into a subfolder, for example http://yoursite.com/store/, AJAX requests initialised in newrelic.js file are not working since their urls are hardcoded to the domain root. Here is a small fix which gets store base url and make urls for AJAX requests depends on the base url. 
